### PR TITLE
Add simple version of get-varargs-list

### DIFF
--- a/modules/macros-core.dt
+++ b/modules/macros-core.dt
@@ -1049,6 +1049,34 @@ the argument to the `uql` and `uql-nc` forms.
       (return (link-nodes-array arg-count-original
                                 arg-array-original))))
 
+
+;;helperfunction only, use the simple version instead
+(def get-varargs-list (macro intern (name (count int))
+  (qq do
+    (def (uq name) (var auto (p DNode)))
+    (new-scope
+      (def argslist (var auto va-list))
+      (va-start (cast (# argslist) (p void)))
+      (setv (uq name) (get-varargs-list mc (uq count) (# argslist)))
+      (va-end (cast (# argslist) (p void)))))))
+
+#|
+@macro std.macros.get-varargs-list
+
+Simple version of `get-varargs-list`, only takes the count as parameter.
+
+@linkage extern
+|#
+
+(def get-varargs-list (macro extern ((count int))
+  (let ((name \ (make-gensym-var-node mc)))
+    (qq do 
+      (get-varargs-list (uq name) (uq count))
+      (move (uq name))))))
+
+
+
+
 (def pool-malloc' (macro extern (n T)
   (bqq cast (pool-malloc mc (* (cast (uq n) size) (sizeof (uq T))))
             (p (uq T)))))


### PR DESCRIPTION
only takes count as parameter, returns the value
